### PR TITLE
[DebianSetupUtility30919] End To End Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+downloads/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo src/./main.sh
 - Nala
 - Git
 - GitK
-- NodeJS
+- Node Version Manager (NVM)
 - Brave
 - Bitwarden
 - Obsidian
@@ -35,7 +35,6 @@ sudo src/./main.sh
 - HomeBank
 - Spotify
 - DBeaver
-- VeraCrypt
 - Okular
 - GNOME Tray Icons
 - Sublime Text
@@ -46,6 +45,4 @@ sudo src/./main.sh
 - JsonCpp
 - MySQL
 - Grub
-- Linux Kernel Headers
-- Nvidia Drivers
 - Git Cola

--- a/src/configure/configureGit.sh
+++ b/src/configure/configureGit.sh
@@ -4,9 +4,9 @@
 
 # Constants
 CONFIGURE="git config --global"
-USERNAME = "b-nagaj"
-EMAIL = "bryce.nagaj@proton.me"
-EDITOR = "subl"
+USERNAME="b-nagaj"
+EMAIL="bryce.nagaj@proton.me"
+EDITOR="subl"
 
 # Customize global scope options
 configure_git_global_options(){

--- a/src/configure/configureNFS.sh
+++ b/src/configure/configureNFS.sh
@@ -17,6 +17,13 @@ create_nfs_mount_point() {
 # Mount the NFS
 mount_nfs() {
 	echo "Establishing a connection with a local NFS..."
-	sudo mount $HOST:$NFS_SHARE_DIRECTORY
+	sudo mount $HOST:$NFS_SHARE_DIRECTORY $MOUNT_POINT
 	echo "Connection established"
+}
+
+# Automatically mount NFS on boot
+save_nfs_config() {
+	echo "Saving NFS configuration..."
+        sudo echo "$HOST:$NFS_SHARE_DIRECTORY $MOUNT_POINT nfs nofail 0 0" >> /etc/fstab
+        echo "Saved"
 }

--- a/src/configure/configureNFS.sh
+++ b/src/configure/configureNFS.sh
@@ -3,9 +3,9 @@
 # Establishes a connection to a local Network File Server (NFS)
 
 # Constants
-MOUNT_POINT = "/home/bryce/Sync"
-HOST = 192.168.50.190
-NFS_SHARE_DIRECTORY = $MOUNT_POINT
+MOUNT_POINT="/home/bryce/Sync"
+HOST="192.168.50.190"
+NFS_SHARE_DIRECTORY=$MOUNT_POINT
 
 # Create a mount point
 create_nfs_mount_point() {

--- a/src/main.sh
+++ b/src/main.sh
@@ -2,14 +2,17 @@
 
 # Runs each component of the setup utility in a sequential fashion
 
+# Store working directory
+CURRENT_WORKING_DIRECTORY=$(dirname $0)
+
 # Import local modules
-. ./packages/updatePackageManager.sh
-. ./packages/installPackages.sh
-. ./packages/purgePackages.sh
-. ./packages/upgradePackageManager.sh
-. ./configure/configureGit.sh
-. ./configure/configureGrub.sh
-. ./configure/configureNFS.sh
+. $CURRENT_WORKING_DIRECTORY/packages/updatePackageManager.sh
+. $CURRENT_WORKING_DIRECTORY/packages/installPackages.sh
+. $CURRENT_WORKING_DIRECTORY/packages/purgePackages.sh
+. $CURRENT_WORKING_DIRECTORY/packages/upgradePackageManager.sh
+. $CURRENT_WORKING_DIRECTORY/configure/configureGit.sh
+. $CURRENT_WORKING_DIRECTORY/configure/configureGrub.sh
+. $CURRENT_WORKING_DIRECTORY/configure/configureNFS.sh
 
 # Entry point
 main() {

--- a/src/main.sh
+++ b/src/main.sh
@@ -27,6 +27,7 @@ main() {
 	configure_git_global_options
 	create_nfs_mount_point
 	mount_nfs
+	save_nfs_config
 	configure_grub
 	echo "Done!"
 }

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -113,7 +113,6 @@ install_flatpaks() {
 install_source() {
     echo "Installing packages from source..."
     cd $DOWNLOADS_DIRECTORY
-    nvm install 22
     $UNPACK $(basename "$OBSIDIAN_SOURCE")
     $UNPACK $(basename "$PROTON_MAIL_SOURCE")
     $UNPACK $(basename "$PROTON_VPN_SOURCE")

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -91,6 +91,7 @@ install_apt_packages() {
     $INSTALL libwxgtk3.2-1 -y
     $INSTALL sublime-text -y
     $INSTALL git-cola -y
+    $INSTALL nfs-common -y
     echo "Installed"
 }
 

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -13,7 +13,6 @@ TRUSTED_KEYRINGS="/etc/apt/trusted.gpg.d"
 APT_REPOSITORIES="/etc/apt/sources.list.d"
 
 # Sources
-FLATHUB_SOURCE="https://dl.flathub.org/repo/flathub.flatpakrepo"
 NODE_SOURCE="https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh"
 BRAVE_SOURCE="https://dl.brave.com/install.sh"
 OBSIDIAN_SOURCE="https://github.com/obsidianmd/obsidian-releases/releases/download/v1.7.7/obsidian_1.7.7_amd64.deb"
@@ -69,7 +68,7 @@ update_software_repositories() {
 install_apt_packages() {
     echo "Installing packages using apt..."
     $INSTALL curl -y
-    $INSTALL flatpak -y
+    $INSTALL snap -y
     $INSTALL gnome-software-plugin-flatpak -y
     $INSTALL nala -y
     $INSTALL git -y
@@ -95,11 +94,10 @@ install_apt_packages() {
     echo "Installed"
 }
 
-# Install packages with flatpak
-install_flatpaks() {
-    echo "Installing packages using flatpak..."
-    sudo flatpak remote-add --if-not-exists flathub $FLATHUB_SOURCE
-    sudo flatpak install flathub com.bitwarden.desktop -y
+# Install packages with snap
+install_snaps() {
+    echo "Installing packages using snap..."
+    sudo snap install bitwarden
     echo "Installed"
 }
 
@@ -123,7 +121,7 @@ install() {
     download_gpg_keys
     update_software_repositories
     install_apt_packages
-    install_flatpaks
+    install_snaps
     install_source
     echo "Installed"
 }

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -72,32 +72,32 @@ update_software_repositories() {
 # Install packages with apt
 install_apt_packages() {
     echo "Installing packages using apt..."
-    $INSTALL curl
-    $INSTALL flatpak
-    $INSTALL gnome-software-plugin-flatpak
-    $INSTALL nala
-    $INSTALL git
-    $INSTALL gitk
-    $INSTALL homebank
-    $INSTALL okular
-    $INSTALL libayatana-appindicator3-1
-    $INSTALL gir1.2-ayatanaappindicator3-0.1
-    $INSTALL gnome-shell-extension-appindicator
-    $INSTALL g++
-    $INSTALL make
-    $INSTALL libboost-all-dev
-    $INSTALL default-libmysqlclient-dev
-    $INSTALL ibcurl4-openssl-dev
-    $INSTALL libjsoncpp-dev
-    $INSTALL grub
-    $INSTALL linux-headers-amd64
-    $INSTALL proton-vpn-gnome-desktop
-    $INSTALL spotify-client
-    $INSTALL libwxgtk3.2-1
-    $INSTALL sublime-text
-    $INSTALL nvidia-driver
-    $INSTALL firmware-misc-nonfree
-    $INSTALL git-cola
+    $INSTALL curl -y
+    $INSTALL flatpak -y
+    $INSTALL gnome-software-plugin-flatpak -y
+    $INSTALL nala -y
+    $INSTALL git -y
+    $INSTALL gitk -y
+    $INSTALL homebank -y
+    $INSTALL okular -y
+    $INSTALL libayatana-appindicator3-1 -y
+    $INSTALL gir1.2-ayatanaappindicator3-0.1 -y
+    $INSTALL gnome-shell-extension-appindicator -y
+    $INSTALL g++ -y
+    $INSTALL make -y
+    $INSTALL libboost-all-dev -y
+    $INSTALL default-libmysqlclient-dev -y
+    $INSTALL ibcurl4-openssl-dev -y
+    $INSTALL libjsoncpp-dev -y
+    $INSTALL grub -y
+    $INSTALL linux-headers-amd64 -y
+    $INSTALL proton-vpn-gnome-desktop -y
+    $INSTALL spotify-client -y
+    $INSTALL libwxgtk3.2-1 -y
+    $INSTALL sublime-text -y
+    $INSTALL nvidia-driver -y
+    $INSTALL firmware-misc-nonfree -y
+    $INSTALL git-cola -y
     echo "Installed"
 }
 
@@ -105,7 +105,7 @@ install_apt_packages() {
 install_flatpaks() {
     echo "Installing packages using flatpak..."
     sudo flatpak remote-add --if-not-exists flathub $FLATHUB_SOURCE
-    sudo flatpak install flathub com.bitwarden.desktop
+    sudo flatpak install flathub com.bitwarden.desktop -y
     echo "Installed"
 }
 

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -83,7 +83,7 @@ install_apt_packages() {
     $INSTALL make -y
     $INSTALL libboost-all-dev -y
     $INSTALL default-libmysqlclient-dev -y
-    $INSTALL ibcurl4-openssl-dev -y
+    $INSTALL openssl -y
     $INSTALL libjsoncpp-dev -y
     $INSTALL grub -y
     $INSTALL proton-vpn-gnome-desktop -y

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -23,7 +23,7 @@ DBEAVER_CE_SOURCE="https://dbeaver.io/files/dbeaver-ce_latest_amd64.deb"
 VERACRYPT_SOURCE="https://launchpad.net/veracrypt/trunk/1.26.14/+download/veracrypt-1.26.14-Debian-12-amd64.deb"
 
 # GPG Keys
-SPOTIFY_GPG="https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg"
+SPOTIFY_GPG="https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg"
 SUBLIME_TEXT_GPG="https://download.sublimetext.com/sublimehq-pub.gpg"
 
 # Repositories

--- a/src/packages/installPackages.sh
+++ b/src/packages/installPackages.sh
@@ -20,7 +20,6 @@ OBSIDIAN_SOURCE="https://github.com/obsidianmd/obsidian-releases/releases/downlo
 PROTON_MAIL_SOURCE="https://proton.me/download/mail/linux/1.6.1/ProtonMail-desktop-beta.deb"
 PROTON_VPN_SOURCE="https://repo.protonvpn.com/debian/dists/stable/main/binary-all/protonvpn-stable-release_1.0.6_all.deb"
 DBEAVER_CE_SOURCE="https://dbeaver.io/files/dbeaver-ce_latest_amd64.deb"
-VERACRYPT_SOURCE="https://launchpad.net/veracrypt/trunk/1.26.14/+download/veracrypt-1.26.14-Debian-12-amd64.deb"
 
 # GPG Keys
 SPOTIFY_GPG="https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg"
@@ -29,7 +28,6 @@ SUBLIME_TEXT_GPG="https://download.sublimetext.com/sublimehq-pub.gpg"
 # Repositories
 SPOTIFY_REPOSITORY="deb http://repository.spotify.com stable non-free"
 SUBLIME_TEXT_REPOSITORY="deb https://download.sublimetext.com/ apt/stable/"
-NVIDIA_DRIVERS_REPOSITORY="deb http://deb.debian.org/debian/ bookworm main contrib non-free non-free-firmware"
 
 # Create a dedicated directory for software downloaded from the web
 create_downloads_directory() {
@@ -47,7 +45,6 @@ download_sources() {
     wget $PROTON_MAIL_SOURCE -P $DOWNLOADS_DIRECTORY
     wget $PROTON_VPN_SOURCE -P $DOWNLOADS_DIRECTORY
     wget $DBEAVER_CE_SOURCE -P $DOWNLOADS_DIRECTORY
-    wget $VERACRYPT_SOURCE -P $DOWNLOADS_DIRECTORY
     echo "Downloaded"
 }
 
@@ -64,7 +61,6 @@ update_software_repositories() {
     echo "Updating software repositories..."
     echo $SPOTIFY_REPOSITORY | sudo tee $APT_REPOSITORIES/spotify.list
     echo $SUBLIME_TEXT_REPOSITORY | sudo tee $APT_REPOSITORIES/sublime-text.list
-    echo $NVIDIA_DRIVERS_REPOSITORY >> $APT_REPOSITORIES
     $UPDATE
     echo "Updated"
 }
@@ -90,13 +86,10 @@ install_apt_packages() {
     $INSTALL ibcurl4-openssl-dev -y
     $INSTALL libjsoncpp-dev -y
     $INSTALL grub -y
-    $INSTALL linux-headers-amd64 -y
     $INSTALL proton-vpn-gnome-desktop -y
     $INSTALL spotify-client -y
     $INSTALL libwxgtk3.2-1 -y
     $INSTALL sublime-text -y
-    $INSTALL nvidia-driver -y
-    $INSTALL firmware-misc-nonfree -y
     $INSTALL git-cola -y
     echo "Installed"
 }
@@ -117,7 +110,6 @@ install_source() {
     $UNPACK $(basename "$PROTON_MAIL_SOURCE")
     $UNPACK $(basename "$PROTON_VPN_SOURCE")
     $UNPACK $(basename "$DBEAVER_CE_SOURCE")
-    $UNPACK $(basename "$VERACRYPT_SOURCE")
     cd ../
     echo "Installed"
 }

--- a/src/packages/purgePackages.sh
+++ b/src/packages/purgePackages.sh
@@ -19,7 +19,7 @@ initialize_purge_list() {
 		["GNOME_CHARACTERS"]="gnome-characters/stable"
 		["GNOME_CHESS"]="gnome-chess/stable"
 		["GNOME_CONTACTS"]="gnome-contacts/stable"
-		["EVOLUTION"]="evolution-data-server-common/stable evolution-data-server/stable"
+		["EVOLUTION"]="evolution*"
 		["FIVE_OR_MORE"]="five-or-more/stable"
 		["FOUR_IN_A_ROW"]="four-in-a-row/stable"
 		["GNOME_NIBBLES"]="gnome-nibbles/stable"
@@ -28,9 +28,9 @@ initialize_purge_list() {
 		["GNOME_MAHJONGG"]="gnome-mahjongg/stable"
 		["GNOME_MAPS"]="gnome-maps/stable"
 		["GNOME_MINES"]="gnome-mines/stable"
-		["GNOME_MUSIC"]="gnome-maps/stable"
+		["GNOME_MUSIC"]="gnome-music/stable"
 		["QUADRAPASSEL"]="quadrapassel/stable"
-		["RYTHMBOX"]="librhythmbox-core10/stable rhythmbox-data/stable rhythmbox-plugin-cdrecorder/stable rhythmbox-plugins/stable rhythmbox/stable"
+		["RHYTHMBOX"]="rhythmbox*"
 		["ROBOTS"]="gnome-robots/stable"
 		["GNOME_SOUND_RECORDER"]="gnome-sound-recorder/stable"
 		["GNOME_SUDOKU"]="gnome-sudoku/stable"
@@ -48,7 +48,7 @@ purge() {
 	initialize_purge_list
 	for key in "${!purgeList[@]}"
 	do
-		$PURGE "${purgeList[$key]}" -y
+	    $PURGE "${purgeList[$key]}" -y
 	done
 	echo "Purged"
 }

--- a/src/packages/purgePackages.sh
+++ b/src/packages/purgePackages.sh
@@ -19,7 +19,7 @@ initialize_purge_list() {
 		["GNOME_CHARACTERS"]="gnome-characters/stable"
 		["GNOME_CHESS"]="gnome-chess/stable"
 		["GNOME_CONTACTS"]="gnome-contacts/stable"
-		["EVOLUTION"]="evolution*"
+		["EVOLUTION"]="evolution evolution-exchange evolution-plugins evolution-common evolution-webcal"
 		["FIVE_OR_MORE"]="five-or-more/stable"
 		["FOUR_IN_A_ROW"]="four-in-a-row/stable"
 		["GNOME_NIBBLES"]="gnome-nibbles/stable"
@@ -50,5 +50,9 @@ purge() {
 	do
 	    $PURGE "${purgeList[$key]}" -y
 	done
+	
+	# Re-install gnome-panel, since purging evolution uninstalls it
+	sudo apt install gnome-panel
+	
 	echo "Purged"
 }

--- a/src/packages/updatePackageManager.sh
+++ b/src/packages/updatePackageManager.sh
@@ -5,6 +5,6 @@
 # Fetch all of the latest updates for packages
 update_package_manager() {
 	echo "Fetching packages from Debian 12 software repositories..."
-    sudo apt update
+        sudo apt update
 	echo "Packages fetched"
 }


### PR DESCRIPTION
## Summary

*A quick glance at the changes that were made*

End-to-end integration testing by using this utility to set up a brand new Debian machine from scratch!

## Changes

*An in-depth look at the changes that were made*

- Resolve any syntax issues that were causing failures:
    - Spacing
    - Typos in package names
- Remove an outdated gpg key for Spotify
- Remove logic to install non-free Nvidia drivers
- Remove the following list of applications from the install list:
    - Veracrypt
    - Nvidia drivers
- Remove nvm install instruction. Only install nvm itself
- Fix relative paths in driver file to import modules correctly
- Add logic for auto-mounting the NFS
- Opt to use snap for Bitwarden instead of flatpak
- Add `nfs-common` to the list of packages to install